### PR TITLE
fix: persist status.sakneen.com custom domain across deploys

### DIFF
--- a/.github/workflows/setup.yml
+++ b/.github/workflows/setup.yml
@@ -35,12 +35,9 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
           token: ${{ secrets.GH_PAT || github.token }}
-      - name: Update template
-        uses: upptime/uptime-monitor@v1.43.7
-        with:
-          command: "update-template"
-        env:
-          GH_PAT: ${{ secrets.GH_PAT || github.token }}
+      # NOTE (Sakneen): the "Update template" step was removed on purpose. It
+      # regenerates the workflow files from the upstream Upptime template, which
+      # drops the peaceiris `cname:` below and unbinds status.sakneen.com.
       - name: Update response time
         uses: upptime/uptime-monitor@v1.43.7
         with:
@@ -80,5 +77,6 @@ jobs:
           github_token: ${{ secrets.GH_PAT || github.token }}
           publish_dir: "site/status-page/__sapper__/export/"
           force_orphan: "false"
+          cname: status.sakneen.com
           user_name: "Upptime Bot"
           user_email: "73812536+upptime-bot@users.noreply.github.com"

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -50,5 +50,6 @@ jobs:
           github_token: ${{ secrets.GH_PAT || github.token }}
           publish_dir: "site/status-page/__sapper__/export/"
           force_orphan: "false"
+          cname: status.sakneen.com
           user_name: "Upptime Bot"
           user_email: "73812536+upptime-bot@users.noreply.github.com"

--- a/.github/workflows/update-template.yml
+++ b/.github/workflows/update-template.yml
@@ -16,8 +16,10 @@
 
 name: Update Template CI
 on:
-  schedule:
-    - cron: "0 0 * * *"
+  # NOTE (Sakneen): scheduled auto-regeneration disabled. update-template rewrites
+  # all workflows from the upstream template and drops the peaceiris `cname:` that
+  # keeps status.sakneen.com bound. Run manually only when intentionally re-syncing
+  # (and re-apply the cname afterwards). See site.yml / setup.yml.
   repository_dispatch:
     types: [update_template]
   workflow_dispatch:

--- a/.github/workflows/updates.yml
+++ b/.github/workflows/updates.yml
@@ -16,8 +16,8 @@
 
 name: Updates CI
 on:
-  schedule:
-    - cron: "0 3 * * *"
+  # NOTE (Sakneen): scheduled auto-update disabled (it can regenerate workflows and
+  # drop the peaceiris `cname:`). Run manually via workflow_dispatch when upgrading.
   repository_dispatch:
     types: [updates]
   workflow_dispatch:


### PR DESCRIPTION
## Fixes the recurring `status.sakneen.com` 404

**Root cause:** Upptime republishes the `gh-pages` branch on every deploy **without a CNAME file**, so GitHub Pages unsets the custom domain and `status.sakneen.com` 404s. The docs say `status-website.cname` should handle this, but in practice the deploy does not persist it — and Upptime's own auto-regeneration would strip any workflow-level fix.

**This PR makes the domain stick:**
- Adds `cname: status.sakneen.com` to the `peaceiris/actions-gh-pages` step in **`site.yml`** and **`setup.yml`** → every deploy now writes the CNAME file.
- Removes Setup CI's `update-template` step, and drops the daily `schedule` on **Update Template CI** and **Updates CI** (kept as manual `workflow_dispatch`) → auto-regeneration can no longer overwrite the workflows and delete the `cname`.

**Trade-off:** the fork is now pinned to `uptime-monitor@v1.43.7`; Upptime upgrades become manual (dispatch "Update Template CI" when you want to re-sync, then re-apply the `cname`). Given the outage that started this was caused by unattended drift, pinned + stable is the safer posture for a status page.

**After merge:** dispatch **Static Site CI** once — it deploys with the `cname`, rebinding the domain permanently. No more add/remove loop.

_Separately (optional): the Cloudflare record for `status.sakneen.com` is **Proxied** (orange cloud). That's why GitHub can't issue its own cert (`cert state: None`) — Cloudflare serves TLS instead, which works. Switching to **DNS-only (grey cloud)** would let GitHub manage the cert natively; not required._

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/Sakneen/codesmith/uptime-status/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785668695&installation_id=142756824&pr_number=65&repository=Sakneen%2Fuptime-status&return_to=https%3A%2F%2Fgithub.com%2FSakneen%2Fuptime-status%2Fpull%2F65&signature=999c7898e4974a50e903bbaa6a941adf5a0f5bc944f1d1564236b0b044dea272"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->